### PR TITLE
Jfajardoh5/auth unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.15
+    
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: t1m0thyj/unlock-keyring@v1
 
     - name: Set up Go
       uses: actions/setup-go@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,9 +5,9 @@ name: Go
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "**" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "**" ]
 
 jobs:
 

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -1,13 +1,13 @@
 package auth
 
 import (
-	"github.com/Reeceeboii/Pi-CLI/pkg/data"
-	"github.com/Reeceeboii/Pi-CLI/pkg/network"
-	"github.com/buger/jsonparser"
-	"github.com/zalando/go-keyring"
 	"io/ioutil"
 	"log"
 	"net/http"
+
+	"github.com/Reeceeboii/Pi-CLI/pkg/network"
+	"github.com/buger/jsonparser"
+	"github.com/zalando/go-keyring"
 )
 
 // Keyring Service: Required for use in authentication and API key management
@@ -52,7 +52,7 @@ func APIKeyIsInKeyring() bool {
 }
 
 // Does an key allow authentication? I.e., is is valid?
-func ValidateAPIKey(key string) bool {
+func ValidateAPIKey(url string, key string) bool {
 	/*
 		To test the validity of the API key, we can attempt to enable the Pi-Hole.
 
@@ -68,9 +68,8 @@ func ValidateAPIKey(key string) bool {
 
 	*/
 
-	url := data.LivePiCLIData.FormattedAPIAddress + "?enable" + "&auth=" + key
-
-	req, err := http.NewRequest("GET", url, nil)
+	queryString := url + "?enable" + "&auth=" + key
+	req, err := http.NewRequest("GET", queryString, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -10,13 +10,11 @@ import (
 	"net/http"
 )
 
-// Constant values required for use in authentication and API key management
-const (
-	// Keyring service
-	KeyringService = "PiCLI"
-	// Keyring user
-	KeyringUsr = "api-key"
-)
+// Keyring Service: Required for use in authentication and API key management
+var KeyringService = "PiCLI"
+
+// Keyring User: Required for use in authentication and API key management
+var KeyringUsr = "api-key"
 
 // Retrieve the API key from the system keyring
 func RetrieveAPIKeyFromKeyring() string {
@@ -28,7 +26,7 @@ func RetrieveAPIKeyFromKeyring() string {
 }
 
 /*
-	Store the API key in the system keyring. Returns an error if this action failed.
+Store the API key in the system keyring. Returns an error if this action failed.
 */
 func StoreAPIKeyInKeyring(key string) error {
 	if err := keyring.Set(KeyringService, KeyringUsr, key); err != nil {

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -1,0 +1,85 @@
+package auth
+
+import (
+	"testing"
+)
+
+const (
+	// Sample API key for test case usage.
+	testKey = "c808f484a4e88cc32a9a8bfcce19169c77bcd9c5eec18d859e1bb4b318bf42bf"
+)
+
+// Calling init() in order to overwrite global variables for test purposes.
+func init() {
+	KeyringService = "test-service" // Overwrite KeyringService for test cases
+	KeyringUsr = "test-key"         // Overwrite KeyringUsr for test cases
+}
+
+/*
+  NOTE:
+  Each test case is self-contained, meaning a key is stored at the beginning of each case and deleted before it ends.
+  We do this because we cannot rely on Go to run its tests sequentially every time.
+*/
+
+// Tests for auth.APIKeyIsInKeyring()
+func TestAPIKeyIsInKeyring(t *testing.T) {
+	// Ensuring StoreAPIKeyInKeyring() can successfully store a key in the keyring.
+	err := StoreAPIKeyInKeyring(testKey)
+	if err != nil {
+		t.Errorf("@TestAPIKeyIsInKeyring: auth.StoreAPIKeyInKeyring() failed to store API key: %s", err)
+	}
+
+	// Ensuring APIKeyIsInKeyring() can successfully find the stored key.
+	if !APIKeyIsInKeyring() {
+		t.Error("@TestAPIKeyIsInKeyring: auth.APIKeyIsInKeyring() failed to find key in keyring.")
+	}
+
+	// Ensuring DeleteAPIKeyFromKeyring() is able to successfully find and delete key
+	if !DeleteAPIKeyFromKeyring() {
+		t.Error("@TestRetrieveAPIKeyFromKeyring: auth.DeleteAPIKeyFromKeyring() did not find/delete key in keyring.")
+	}
+
+	// Ensuring APIKeyIsInKeyring() cannot find a key that should not exist.
+	if APIKeyIsInKeyring() {
+		t.Error("@TestAPIKeyIsInKeyring: auth.APIKeyIsInKeyring() found key in keyring after it should have been deleted.")
+	}
+}
+
+// Tests for auth.RetrieveAPIKeyFromKeyring()
+func TestRetrieveAPIKeyFromKeyring(t *testing.T) {
+	// Ensuring StoreAPIKeyInKeyring() can successfully store a key in the keyring.
+	err := StoreAPIKeyInKeyring(testKey)
+	if err != nil {
+		t.Errorf("@TestRetrieveAPIKeyFromKeyring: auth.StoreAPIKeyInKeyring() failed to store API key: %s", err)
+	}
+
+	// Ensuring RetrieveAPIKeyFromKeyring() can successfully find the right key in keyring.
+	key := RetrieveAPIKeyFromKeyring()
+	if key != testKey {
+		t.Error("@TestRetrieveAPIKeyFromKeyring: auth.RetrieveAPIKeyFromKeyring() did not match provided test key.")
+	}
+
+	// Ensuring DeleteAPIKeyFromKeyring() is able to successfully find and delete key
+	if !DeleteAPIKeyFromKeyring() {
+		t.Error("@TestRetrieveAPIKeyFromKeyring: auth.DeleteAPIKeyFromKeyring() did not find/delete key in keyring.")
+	}
+}
+
+// Tests for auth.DeleteAPIKeyFromKeyring()
+func TestDeleteAPIKeyFromKeyring(t *testing.T) {
+	// Ensuring StoreAPIKeyInKeyring() can successfully store a key in the keyring.
+	err := StoreAPIKeyInKeyring(testKey)
+	if err != nil {
+		t.Errorf("@TestDeleteAPIKeyFromKeyring: auth.StoreAPIKeyInKeyring() failed to store API key: %s", err)
+	}
+
+	// Ensuring DeleteAPIKeyFromKeyring() is able to successfully find and delete key
+	if !DeleteAPIKeyFromKeyring() {
+		t.Error("@TestDeleteAPIKeyFromKeyring: auth.DeleteAPIKeyFromKeyring() did not find/delete key in keyring.")
+	}
+
+	// Ensuring DeleteAPIKeyFromKeyring() does not find or delete a key as expected when the key does not exist.
+	if DeleteAPIKeyFromKeyring() {
+		t.Error("@TestDeleteAPIKeyFromKeyring: auth.DeleteAPIKeyFromKeyring() found/deleted key from keyring when one should not exist, it should have been deleted in the previous assertion.")
+	}
+}

--- a/pkg/cli/setupCmd.go
+++ b/pkg/cli/setupCmd.go
@@ -17,17 +17,17 @@ import (
 )
 
 /*
-	Reads in data from the user and uses it to construct a config file that Pi-CLI can use
-	in the future.
+Reads in data from the user and uses it to construct a config file that Pi-CLI can use
+in the future.
 
-	The setup commands takes:
-		- The IP address of the target Pi-Hole instance
-		- The port exposing the Pi-Hole's web interface
-		- A data refresh rate in seconds
-		- User's Pi-Hole API key (used for authentication)
+The setup commands takes:
+  - The IP address of the target Pi-Hole instance
+  - The port exposing the Pi-Hole's web interface
+  - A data refresh rate in seconds
+  - User's Pi-Hole API key (used for authentication)
 
-	It will then ask them if they wish to store the API key in their system keyring or the config
-	file itself.
+It will then ask them if they wish to store the API key in their system keyring or the config
+file itself.
 */
 func SetupCommand(c *cli.Context) error {
 	reader := bufio.NewReader(os.Stdin)
@@ -143,7 +143,7 @@ func SetupCommand(c *cli.Context) error {
 			data.PICLISettings.PiHoleAddress,
 			data.PICLISettings.PiHolePort)
 
-		if !auth.ValidateAPIKey(data.PICLISettings.APIKey) {
+		if !auth.ValidateAPIKey(data.LivePiCLIData.FormattedAPIAddress, data.PICLISettings.APIKey) {
 			color.Yellow("That API token doesn't seem to be correct, check it and try again!")
 		} else {
 			break


### PR DESCRIPTION
## Task 

### [#24](https://github.com/Reeceeboii/Pi-CLI/issues/24) Make Pi-CLI more unit-testable & Set up CI


## Contribution

*	Unit tests were added for the 'auth' package, located at pkg/auth/auth_test.go

*	CI workflow has been added for running tests on 'push' and on 'pull_request'

## Changes made

### 1- Const variables KeyringService & KeyringUsr were re-factored into mutable vars
* We changed these in order to be able to overwrite them for running our tests in an isolated environment.

*	This change has been tested both manually and programmatically and works exactly as it did before.

### 2- We are now passing the base url for our pi-hole server into ValidateAPIKey() as a parameter
 	
*	This change also required modifying how this function is called in pkg/cli/setupCmd.go

*	It has been tested both manually and programmatically and works exactly as it did before.

### 3- All functions within the 'auth' package are now covered with unit tests 

See pkg/auth/auth_test.go

### 4- CI workflow was added for running tests

Along with introducing these tests, we have also set up a CI workflow for running tests on 'push' and on 'pull_request' for any branch under this project.

Note that this workflow file uses the action 't1m0thyj/unlock-keyring@v1'. This was a huge boon. It took some time to figure out how we could have access to gnome-keyring in our workflow runtime, and this action completely takes care of it.

## Note

The issue this pull request intends to address is still far away from resolution, but it is a step forward.
